### PR TITLE
Add auto tests

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,16 @@
+name: Continuous Integration
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10.0
+          architecture: x64
+      - name: Install dependencies
+        run: pip install -r requirements.txt 
+      - name: Run Tests
+        run: python -m pytest


### PR DESCRIPTION
The unittests.yaml file introduces a new GitHub Action named Continuous Integration that is triggered on push, meaning that everytime a developer pushes a code to a branch where this file exists. The action then runs the steps in the order of their definition on an ubuntu-latest container. The steps are: Checking out to the current Git branch Set up Python on the container Install the Python dependencies of the Bank Account app defined in requirements.txt Run the unit tests using Pytest